### PR TITLE
[TE-18111] Restored concurrent dictionary backing of method resolution (<=13)

### DIFF
--- a/src/NVelocity/Util/Introspection/ClassMap.cs
+++ b/src/NVelocity/Util/Introspection/ClassMap.cs
@@ -16,7 +16,7 @@ namespace NVelocity.Util.Introspection
 {
 	using System;
 	using System.Collections;
-	using System.Collections.Generic;
+	using System.Collections.Concurrent;
 	using System.Reflection;
 	using System.Text;
 
@@ -37,11 +37,11 @@ namespace NVelocity.Util.Introspection
 		/// <summary> Cache of Methods, or CACHE_MISS, keyed by method
 		/// name and actual arguments used to find it.
 		/// </summary>
-		private readonly Dictionary<string, MethodInfo> methodCache =
-			new Dictionary<string, MethodInfo>(StringComparer.OrdinalIgnoreCase);
+		private readonly ConcurrentDictionary<string, MethodInfo> methodCache =
+			new ConcurrentDictionary<string, MethodInfo>(StringComparer.OrdinalIgnoreCase);
 
-		private readonly Dictionary<string, MemberInfo> propertyCache =
-			new Dictionary<string, MemberInfo>(StringComparer.OrdinalIgnoreCase);
+		private readonly ConcurrentDictionary<string, MemberInfo> propertyCache =
+			new ConcurrentDictionary<string, MemberInfo>(StringComparer.OrdinalIgnoreCase);
 
 		private readonly MethodMap methodMap = new MethodMap();
 


### PR DESCRIPTION
This used to use `ConcurrentDictionary` prior to [this change](https://github.com/Telligent/NVelocity/commit/569b2334646e62b4c3926cf1f56b7e23be285af4?diff=unified#diff-d9c569b33a83d18bc2ae80f30dcef3a87b13081cc85e78e8cd204ced8ab9d7f3). I see no reason not to restore it, especially as it seems to be the cause for [TE-18111](https://verintcommunity.atlassian.net/browse/TE-18111).